### PR TITLE
fix bug/typo in infinite-scroll.md

### DIFF
--- a/src/docs/infinite-scroll.md
+++ b/src/docs/infinite-scroll.md
@@ -18,12 +18,13 @@ function App() {
 function myFetchFunction () {
   setIsLoading(true);
   setIsError(false);
-  setPage(page => page + 1);
+  
 
   fetch('https://myapi.com/mylist')
     .then(res => res.json())
     .then(data => {
       setList(list.concat(data));
+      setPage(page => page + 1);
       setIsLoading(false);
       setIsError(false);
     })


### PR DESCRIPTION
moved the setPage function inside the fetch chain instead of outside because it was fetching from page 2 instead of 1.